### PR TITLE
Fix: Add origin to support remote branches 

### DIFF
--- a/modules-detection.mjs
+++ b/modules-detection.mjs
@@ -14,6 +14,7 @@ async function detect() {
         return;
     }
 
+    await $`git fetch`;
     const { stdout: fileChangesRaw } = await $`git diff --name-only  ${sourceRef}..origin/${targetRef}`;
 
     const fileChanges = fileChangesRaw.trim().split('\n');

--- a/modules-detection.mjs
+++ b/modules-detection.mjs
@@ -14,7 +14,7 @@ async function detect() {
         return;
     }
 
-    const { stdout: fileChangesRaw } = await $`git diff --name-only  ${sourceRef}..${targetRef}`;
+    const { stdout: fileChangesRaw } = await $`git diff --name-only  ${sourceRef}..origin/${targetRef}`;
 
     const fileChanges = fileChangesRaw.trim().split('\n');
     const filteredFileChanges = fileChanges.filter(file => file.startsWith(workingDir));


### PR DESCRIPTION
Env0 only clones the target branches. But if we need to compere to branch which not the master. we need to learn git about him.

Use `git fetch` and `origin` for pull this metadata 