### PR TITLE
FIx - `git diff` fail with "ambiguous argument" error

### DIFF
--- a/env0.plugin.yml
+++ b/env0.plugin.yml
@@ -2,5 +2,4 @@ name: terragrunt-modules-detection
 inputs: {}
 run:
   exec: |
-    npm i zx
-    npx zx $ENV0_PLUGIN_PATH/modules-detection.mjs
+    npx --yes zx --verbose $ENV0_PLUGIN_PATH/modules-detection.mjs

--- a/modules-detection.mjs
+++ b/modules-detection.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env zx
 
-const { ENV0_PR_SOURCE_BRANCH, ENV0_PR_TARGET_BRANCH, ENV0_TEMPLATE_PATH } = process.env;
+const {ENV0_PR_SOURCE_BRANCH, ENV0_PR_TARGET_BRANCH, ENV0_TEMPLATE_PATH} = process.env;
 
 const sourceRef = ENV0_PR_SOURCE_BRANCH;
 const targetRef = ENV0_PR_TARGET_BRANCH;
@@ -15,7 +15,11 @@ async function detect() {
     }
 
     await $`git fetch`;
-    const { stdout: fileChangesRaw } = await $`git diff --name-only  ${sourceRef}..origin/${targetRef}`;
+
+    const {stdout: branches} = await $`git branch -a`;
+    console.log(`All branches:\n${branches}`)
+
+    const {stdout: fileChangesRaw} = await $`git diff --name-only  ${'refs/heads/' + sourceRef}..${'refs/remotes/origin/' + targetRef}`;
 
     const fileChanges = fileChangesRaw.trim().split('\n');
     const filteredFileChanges = fileChanges.filter(file => file.startsWith(workingDir));

--- a/modules-detection.mjs
+++ b/modules-detection.mjs
@@ -2,24 +2,23 @@
 
 const {ENV0_PR_SOURCE_BRANCH, ENV0_PR_TARGET_BRANCH, ENV0_TEMPLATE_PATH} = process.env;
 
-const sourceRef = ENV0_PR_SOURCE_BRANCH;
-const targetRef = ENV0_PR_TARGET_BRANCH;
+const sourceBranch = ENV0_PR_SOURCE_BRANCH;
+const targetBranch = ENV0_PR_TARGET_BRANCH;
 const workingDir = ENV0_TEMPLATE_PATH || ''
 
 await detect();
 
 async function detect() {
-    if (!sourceRef || !targetRef) {
-        console.log(`Skipping - can't detect source or target refs. source [${sourceRef}] target [${targetRef}]`);
+    if (!sourceBranch || !targetBranch) {
+        console.log(`Skipping - can't detect source or target branch. Source [${sourceBranch}] target [${targetBranch}]`);
         return;
     }
 
-    await $`git fetch`;
+    await $`git fetch origin ${targetBranch + ':refs/remotes/origin/' + targetBranch}`;
 
-    const {stdout: branches} = await $`git branch -a`;
-    console.log(`All branches:\n${branches}`)
+    await $`git branch -a`;
 
-    const {stdout: fileChangesRaw} = await $`git diff --name-only  ${'refs/heads/' + sourceRef}..${'refs/remotes/origin/' + targetRef}`;
+    const {stdout: fileChangesRaw} = await $`git diff --name-only ${sourceBranch}..${'remotes/origin/' + targetBranch}`;
 
     const fileChanges = fileChangesRaw.trim().split('\n');
     const filteredFileChanges = fileChanges.filter(file => file.startsWith(workingDir));


### PR DESCRIPTION
### Issue
`git diff` is failing with "ambiguous argument" error

### Solution
- Fetch the target branch explicitly
- Use `remotes/origin/<targetBranch>` in the `git diff` command
- Use `--verbose` flag in the `npx` command to show executed commands and outputs in the log